### PR TITLE
Actually pass the TERM value we requested

### DIFF
--- a/gnome_connection_manager.py
+++ b/gnome_connection_manager.py
@@ -450,7 +450,7 @@ def vte_feed(terminal, data):
         terminal.feed_child(data, len(data))
 
 def vte_run(terminal, command, arg=None):
-    envv = [ 'PATH=%s' % (os.getenv("PATH")) ]
+    envv = [ 'PATH=%s' % (os.getenv("PATH")), 'TERM=%s' % (os.getenv("TERM")) ]
     args = []
     args.append(command)
     if arg:


### PR DESCRIPTION
The `vte_run()` does pass some envvars from GCM to the new shell, but TERM is not in the list.

Helps to address part of #5.