### PR TITLE
Fix SyntaxError in Python3 < 3.5

### DIFF
--- a/gnome_connection_manager.py
+++ b/gnome_connection_manager.py
@@ -3428,7 +3428,7 @@ class CellTextView(Gtk.TextView, Gtk.CellEditable):
     def get_text(self):
         text_buffer = self.get_buffer()
         bounds = text_buffer.get_bounds()
-        return text_buffer.get_text(*bounds, True)
+        return text_buffer.get_text(*bounds, include_hidden_chars=True)
 
     def set_text(self, text):
         self.get_buffer().set_text(text)


### PR DESCRIPTION
Fixes python exception:

  File "./gnome_connection_manager.py", line 3362
    return text_buffer.get_text(*bounds, True)
SyntaxError: only named arguments may follow *expression